### PR TITLE
lock bootstrap-sass-official version to 3.3.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "calcite-bootstrap",
   "private": true,
   "dependencies": {
-    "bootstrap-sass-official": "~3.3.1",
+    "bootstrap-sass-official": "3.3.3",
     "modernizr": "~2.8.1"
   }
 }


### PR DESCRIPTION
Something changed after bootstrap-sass-official v3.3.3 that breaks this app.
