### PR TITLE
Custom class for ArcGIS branding

### DIFF
--- a/app/pages/typography.hbs
+++ b/app/pages/typography.hbs
@@ -254,6 +254,18 @@ layout: layout.hbs
               </div><!-- /.panel-footer -->
             </div><!-- /.panel -->	
 
+          <h4>ArcGIS Branding</h4>
+            <p>When the branding of ArcGIS is needed, use the <code>gis</code> inside of a <code>&lt;span&gt;</code> around the letters GIS.
+            <div class="panel panel-default">
+              <div class="panel-body">
+                <p>Arc<span class="gis">GIS</span></p>
+              </div><!-- /.panel-body -->
+              <div class="panel-footer">
+                <p class="code-face">Arc<code>&lt;span class="gis"&gt;</code>GIS<code>&lt;/span&gt;</code></p>
+              </div><!-- /.panel-footer -->
+            </div><!-- /.panel -->  
+
+
 					<h3 id="alignment">Alignment Classes</h3>
 					<p>Easily realign text to components with text alignment classes.</p>
 				    <div class="panel panel-default">

--- a/app/styles/calcite/_type-custom.scss
+++ b/app/styles/calcite/_type-custom.scss
@@ -31,3 +31,8 @@ h6, .h6 {
 blockquote {
   font-family: $font-family-serif;
 }
+
+// Use the class below in a span around GIS when branding ArcGIS
+.gis {
+	font-weight: 500; 
+}


### PR DESCRIPTION
Added a simple class to use for branding. This bumps the font-weight to 500 from the base-weight of 300.

Making the rule-of-thumb as weight is 200 more than its parent. (In the navbar links will be 400, so the bump there will be 600).
