### PR TITLE
Closes bug #90

### DIFF
--- a/app/styles/calcite/_navbar-custom.scss
+++ b/app/styles/calcite/_navbar-custom.scss
@@ -6,6 +6,7 @@
 .navbar-toggle{
   float: left;
   margin-left: $navbar-padding-horizontal;
+  margin-right: 0px;
 }
 
 // Sets the font-size of the brand and navbar links slightly smaller than base


### PR DESCRIPTION
This fix just adjusts the spacing to the right of the hamburger when in mobile mode. Following Calcite-Web we'll keep it on the left until a decision is made about the mobile nav pattern.
