### PR TITLE
Fixed javascript bug preventing tooltips from working and added styling

### DIFF
--- a/app/layouts/docs.hbs
+++ b/app/layouts/docs.hbs
@@ -8,6 +8,7 @@
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
     <link rel="stylesheet" href="{{assets}}styles/calcite-bootstrap.css">
     <script src="{{assets}}scripts/head.js"></script>
+
   </head>
   <body>
     <!--[if lt IE 10]>
@@ -19,5 +20,13 @@
     <script src="{{assets}}scripts/vendor.js"></script>
     <script src="{{assets}}scripts/plugins.js"></script>
     <script src="{{assets}}scripts/main.js"></script>
+    <script>
+      $(function () { 
+        $("[data-toggle='tooltip']").tooltip(); 
+      });
+      $(function () { 
+        $("[data-toggle='popover']").popover(); 
+      });
+    </script>
 </body>
 </html>

--- a/app/pages/docs/tooltip.hbs
+++ b/app/pages/docs/tooltip.hbs
@@ -2,12 +2,6 @@
 layout: docs.hbs
 ---
 
-<script>
-  $(function () {
-    $('[data-toggle="tooltip"]').tooltip()
-  })
-</script>
-
 <div class="cal-header">
   <div class="container">
     <h1>Tooltip</h1>
@@ -23,8 +17,8 @@ layout: docs.hbs
     </div><!-- /.col-* -->
     <div class="col-md-9">
       <div class="panel panel-default">
-        <div class="panel-body">        
-          <p>Tight pants next level keffiyeh <a href="#" data-toggle="tooltip" title="" data-original-title="Default tooltip">you probably</a> haven't heard of them. Photo booth beard raw denim letterpress vegan messenger bag stumptown. Farm-to-table seitan, mcsweeney's fixie sustainable quinoa 8-bit american apparel <a href="#" data-toggle="tooltip" title="" data-original-title="Another tooltip">have a</a> terry richardson vinyl chambray. Beard stumptown, cardigans banh mi lomo thundercats. Tofu biodiesel williamsburg marfa, four loko mcsweeney's cleanse vegan chambray. A really ironic artisan <a href="#" data-toggle="tooltip" title="Another one here too">whatever keytar</a>, scenester farm-to-table banksy Austin <a href="#" data-toggle="tooltip" title="The last tip!">twitter handle</a> freegan cred raw denim single-origin coffee viral.</p>
+        <div class="panel-body">          
+          <p>Tight pants next level keffiyeh <a href="#" data-toggle="tooltip" title="" data-placement="top" data-original-title="Default tooltip">you probably</a> haven't heard of them. Photo booth beard raw denim letterpress vegan messenger bag stumptown. Farm-to-table seitan, mcsweeney's fixie sustainable quinoa 8-bit american apparel <a href="#" data-toggle="tooltip" title="" data-original-title="Another tooltip">have a</a> terry richardson vinyl chambray. Beard stumptown, cardigans banh mi lomo thundercats. Tofu biodiesel williamsburg marfa, four loko mcsweeney's cleanse vegan chambray. A really ironic artisan <a href="#" data-toggle="tooltip" title="Another one here too">whatever keytar</a>, scenester farm-to-table banksy Austin twitter handle freegan cred raw denim single-origin coffee viral.</p>
         </div>
         <div class="panel-footer">
           <p class="mono">
@@ -45,13 +39,13 @@ layout: docs.hbs
       <div class="panel panel-default">
         <div class="panel-body">
 
-          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="Tooltip on left">Tooltip on left</button>
+          <p><button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="Tooltip on left">Tooltip on left</button></p>
 
-          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Tooltip on top">Tooltip on top</button>
+          <p><button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Tooltip on top">Tooltip on top</button></p>
 
-          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button>
+          <p><button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button></p>
 
-          <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="Tooltip on right">Tooltip on right</button>
+          <p><button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="Tooltip on right">Tooltip on right</button></p>
 
         </div>
         <div class="panel-footer">

--- a/app/styles/calcite/_tooltips-custom.scss
+++ b/app/styles/calcite/_tooltips-custom.scss
@@ -1,0 +1,3 @@
+.tooltip-inner {
+	padding: 6px 12px;
+}

--- a/app/styles/calcite/_tooltips.scss
+++ b/app/styles/calcite/_tooltips.scss
@@ -8,7 +8,7 @@ $tooltip-max-width:           200px !default;
 $tooltip-color:               $Calcite_Gray_050 !default;
 //** Tooltip background color
 $tooltip-bg:                  $Calcite_Gray_700 !default;
-$tooltip-opacity:             .9 !default;
+$tooltip-opacity:             .85 !default;
 
 //** Tooltip arrow width
 $tooltip-arrow-width:         5px !default;

--- a/app/styles/calcite/calcite-custom.scss
+++ b/app/styles/calcite/calcite-custom.scss
@@ -21,7 +21,7 @@
 @import "pager-custom";
 // @import "jumbotron-custom";
 // @import "formstates-custom";
-// @import "tooltips-custom";
+@import "tooltips-custom";
 // @import "popovers-custom";
 @import "labels-custom";
 // @import "modals-custom";


### PR DESCRIPTION
This fixes and closes issue #118 for Tooltips. New examples shown below:

![screen shot 2015-08-11 at 3 49 35 pm](https://cloud.githubusercontent.com/assets/5419306/9208392/3f58cd0a-4041-11e5-9476-87d6a56d6506.png)

![screen shot 2015-08-11 at 3 49 43 pm](https://cloud.githubusercontent.com/assets/5419306/9208396/43f5a360-4041-11e5-9c9c-1c788343d1da.png)
