### PR TITLE
Stateful button is depricated

### DIFF
--- a/app/pages/docs/button.hbs
+++ b/app/pages/docs/button.hbs
@@ -11,31 +11,6 @@ layout: docs.hbs
 
   <div class="row">
     <div class="col-md-3">
-      <h3>Stateful</h3>
-      <p><!-- DESCRIPTION --></p>
-    </div><!-- /.col-* -->
-    <div class="col-md-9">
-      <div class="panel panel-default">
-        <div class="panel-body">
-
-          <button type="button" id="loading-example-btn" data-loading-text="Loading..." class="btn btn-primary" autocomplete="off">
-            Loading state
-          </button>
-          
-        </div>
-        <div class="panel-footer">
-          <p class="mono">
-            <!-- INSERT CODE VIEW -->
-          </p>
-        </div>
-        </div>
-    </div><!-- /.col-* -->
-  </div><!-- /.row -->
-
-
-
-  <div class="row">
-    <div class="col-md-3">
       <h3>Single Toggle</h3>
       <p><!-- DESCRIPTION --></p>
     </div><!-- /.col-* -->


### PR DESCRIPTION
This button type was deprecated in bootstrap 3.4 and is being removed in bootstrap 4. Removing it from the docs as we will no longer support it either.
