### PR TITLE
Fix font paths in calcite-bootstrap

### DIFF
--- a/app/styles/bootstrap-core.scss
+++ b/app/styles/bootstrap-core.scss
@@ -1,4 +1,4 @@
-$icon-font-path: '../fonts/';
+$icon-font-path: './fonts/';
 
 /* @import "bootstrap/variables";*/
 @import "bootstrap/mixins";


### PR DESCRIPTION
Fixing paths for fonts when referencing the `calcite-bootstrap.css` from an outside location. For #155.
