### PR TITLE
Travis deploy adjusted to build without livereload

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ -n "${GH_TOKEN}" ] && [ "$TRAVIS_PULL_R
 
   # run our compile script
   #gulp build
-  grunt build
+  grunt publish
 
   # go to the dist directory and create a *new* Git repo
   cd dist


### PR DESCRIPTION
`grunt build` to `grunt publish` to remove livereload from build to gh-pages
