### PR TITLE
Removed ... from Loader animation

### DIFF
--- a/lib/sass/calcite/_loader.scss
+++ b/lib/sass/calcite/_loader.scss
@@ -63,9 +63,6 @@ $include-loader: true;
   text-align: center;
   padding-top: 4rem;
   @extend .avenir-regular;
-  &:after {
-    content: "…";
-  }
 }
 
 @if $include-loader == true {


### PR DESCRIPTION
Simple change to remove the ellipsis that are added by Sass to the end. This sometimes poses a problem in translations.
