### PR TITLE
Fixes bug #187

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Calcite+Bootstrap CHANGELOG
 
+## v0.2.6
+### Bugs
+- Bug causing primary typeface in body font stack to be dropped in both builds.
+
 ## v0.2.5
 - Compiled Calcite variables files into a single _variables.scss file.
 - Added Calcite-Web loading animation

--- a/lib/sass/calcite/_variables.scss
+++ b/lib/sass/calcite/_variables.scss
@@ -47,8 +47,8 @@ $link-hover-decoration: underline !default;
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-$font-family-sans-serif:  'Helvetica Neue', 'Helvetica', 'Arial', sans-serif !default;
-$font-family-serif:       Georgia, serif !default;
+$font-family-sans-serif:  $primary-font-sanserif, 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif !default;
+$font-family-serif:       $primary-font-serif, Georgia, serif !default;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
 $font-family-monospace:   'Consolas', 'Andale Mono', 'Lucida Console', 'Monaco', 'Courier New', Courier, monospace !default;
 $font-family-base:        $font-family-sans-serif !default;
@@ -70,8 +70,8 @@ $line-height-base:        1.5 !default; // 16/24
 $line-height-computed:    floor(($font-size-base * $line-height-base)) !default; // ~20px
 
 //** By default, this inherits from the `<body>`.
-$headings-font-family:    'Helvetica Neue', 'Helvetica', 'Arial', sans-serif !default;
-$headings-font-weight:    300 !default;
+$headings-font-family:    $primary-font-sanserif, 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif !default;
+$headings-font-weight:    $primary-headings-weight !default;
 $headings-line-height:    1.2 !default;
 $headings-color:          inherit !default;
 

--- a/lib/sass/calcite/calcite-open.scss
+++ b/lib/sass/calcite/calcite-open.scss
@@ -1,10 +1,11 @@
 // Calcite Fast Fonts Imports
 @import "fonts-opensans";
 
+// Set variable to change the primary typeface in the font stack
+$primary-font-sanserif: 'Open Sans';
+$primary-font-serif: '';
+
+$primary-headings-weight: 200;
+
 // Calcite Module Variables
 @import "variables";
-
-//append on the Open Sans Fonts
-$font-family-sans-serif: 'Open Sans', $font-family-sans-serif;
-$headings-font-family:   'Open Sans', $headings-font-family;
-

--- a/lib/sass/calcite/calcite.scss
+++ b/lib/sass/calcite/calcite.scss
@@ -1,10 +1,11 @@
 // Calcite Fast Fonts Imports
 @import "fonts-avenir";
 
+// Set variable to change the primary typeface in the font stack
+$primary-font-sanserif:  'Avenir Next W01', 'Avenir Next', 'Avenir';
+$primary-font-serif: 'Kepler W01';
+
+$primary-headings-weight: 300;
+
 // Calcite Module Variables
 @import "variables";
-
-//append on the Avenir Fonts
-$font-family-sans-serif: 'Avenir Next W01', 'Avenir Next', 'Avenir', $font-family-sans-serif;
-$headings-font-family:   'Avenir Next W01', 'Avenir Next', 'Avenir',$headings-font-family;
-$font-family-serif:       'Kepler W01',$font-family-serif;


### PR DESCRIPTION
Had to change the way the primary typeface was being pulled into the two build variable files. Having the variable reference itself, it was being dropped in after the first use in the variables.
