### PR TITLE
Add fluid class for footer text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Calcite+Bootstrap CHANGELOG
 
+## v0.2.7
+- Calcite Dark colors finalized
+### Bugs
+- Class to center text in the footer now works in both container types.
+
 ## v0.2.6
 ### Bugs
 - Bug causing primary typeface in body font stack to be dropped in both builds.

--- a/lib/sass/calcite/_sticky-footer.scss
+++ b/lib/sass/calcite/_sticky-footer.scss
@@ -4,10 +4,6 @@
 
 //== Let's make the footer stick to the bottom when the page is short!
 
-// Footer Variables
-$footer-height: 60px;
-$footer-bg: $Calcite_Gray_150;
-
 // Footer CSS
 html {
   position: relative;
@@ -25,6 +21,6 @@ body {
   background-color: $footer-bg;
 }
 /* This centers the text vertically in the footer */
-.container .text-muted {
+.container .text-muted, .container-fluid .text-muted {
   margin: 18px 0;
 }


### PR DESCRIPTION
Class that centered footer text vertically left was defined only for `.container`. Added `.container-fluid` to same rule so users can make footers fluid width.

The variables for the custom footer were duplicated in the sticky footer file. Removed these just as a matter of clean-up and leaving the only variables for footer in custom-footer.