### PR TITLE
Consolidate custom variable definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.2.7
 - Calcite Dark colors finalized
+- Consolidated custom variable definitions into `_variables.scss` file.
 ### Bugs
 - Class to center text in the footer now works in both container types.
 

--- a/lib/sass/calcite/_card-custom.scss
+++ b/lib/sass/calcite/_card-custom.scss
@@ -1,6 +1,6 @@
-$card-width: 255px;
-$card-thumb-max-height: 133px;
-$card-thumb-max-width: 200px;
+// ┌───────┐
+// │ Cards │
+// └───────┘
 
 .cards-list {
   margin: 0;

--- a/lib/sass/calcite/_footer-custom.scss
+++ b/lib/sass/calcite/_footer-custom.scss
@@ -1,6 +1,3 @@
 // ┌────────┐
 // │ Footer │
 // └────────┘
-
-$footer-height: 60px;
-$footer-bg: $Calcite_Gray_150;

--- a/lib/sass/calcite/_header-custom.scss
+++ b/lib/sass/calcite/_header-custom.scss
@@ -2,18 +2,6 @@
 // │ Calcite Header │
 // └────────────────┘
 
-$calcite-tabs-border-color:                     transparent !default;
-
-$calcite-tabs-link-hover-border-color:          $gray-lighter !default;
-
-$calcite-tabs-active-link-hover-bg:             $body-bg !default;
-$calcite-tabs-active-link-hover-color:          $Calcite_Gray_700 !default;
-$calcite-tabs-active-link-hover-border-color:   $Calcite_Gray_400 !default;
-
-$calcite-link-hover-bg:                         $Calcite_Gray_700 !default;
-
-$calcite-header-margin-bottom:									30px; // Padding below header
-
 .cal-header {
 	position: relative;
 	padding: 30px 15px 0px 15px;

--- a/lib/sass/calcite/_loader.scss
+++ b/lib/sass/calcite/_loader.scss
@@ -5,16 +5,6 @@
 //  Line 15 is a shortcircuit of functionality found in Calcite-Web
 //  Color variables have been changed to $Calcite-*
 
-
-$loader-width: 0.85rem;
-$loader-height: 2rem;
-$loader-zoom: 0.5rem;
-$loader-spacing: 1.25rem;
-$loader-speed: 0.8s;
-$loader-delay: 0.16s;
-
-$include-loader: true;
-
 @mixin loader() {
   display: none;
   position: relative;

--- a/lib/sass/calcite/_navs-custom.scss
+++ b/lib/sass/calcite/_navs-custom.scss
@@ -2,9 +2,6 @@
 // │ Navs - Custom │
 // └───────────────┘
 
-$subheader-navbar-height: 36px;
-$micro-navbar-height: 22px;
-
 .subheader-nav {
   position: relative;
   min-height: $subheader-navbar-height;

--- a/lib/sass/calcite/_variables.scss
+++ b/lib/sass/calcite/_variables.scss
@@ -875,3 +875,56 @@ $page-header-border-color:    $gray-lighter !default;
 $dl-horizontal-offset:        $component-offset-horizontal !default;
 //** Horizontal line color.
 $hr-border:                   $gray-lighter !default;
+
+
+
+//
+// Calcite+Bootstrap Custom Variables
+// --------------------------------------------------
+
+
+//== Cards
+//
+//##
+$card-width: 255px;
+$card-thumb-max-height: 133px;
+$card-thumb-max-width: 200px;
+
+//== Footer
+//
+//##
+$footer-height: 60px;
+$footer-bg: $Calcite_Gray_150;
+
+//== Header
+//
+//##
+$calcite-tabs-border-color: transparent !default;
+
+$calcite-tabs-link-hover-border-color: $gray-lighter !default;
+
+$calcite-tabs-active-link-hover-bg: $body-bg !default;
+$calcite-tabs-active-link-hover-color: $Calcite_Gray_700 !default;
+$calcite-tabs-active-link-hover-border-color: $Calcite_Gray_400 !default;
+
+$calcite-link-hover-bg: $Calcite_Gray_700 !default;
+
+$calcite-header-margin-bottom: 30px; // Padding below header
+
+//== Loader
+//
+//##
+$loader-width: 0.85rem;
+$loader-height: 2rem;
+$loader-zoom: 0.5rem;
+$loader-spacing: 1.25rem;
+$loader-speed: 0.8s;
+$loader-delay: 0.16s;
+
+$include-loader: true;
+
+//== Navs
+//
+//##
+$subheader-navbar-height: 36px;
+$micro-navbar-height: 22px;


### PR DESCRIPTION
Removed custom variable definitions from several module css files and moved them into the core `_variables.scss` file. 