### PR TITLE
Adjustments made for issue #214 and #223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 For information about how to add entries to this file, please read [Keep a CHANGELOG](http://keepachangelog.com/)
 
+## v0.2.11
+### Changed
+- Changed background color on hover for `.btn-default`, `.btn-primary`, `.btn-success`, `.btn-info`, `.btn-warning` and `.btn-danger` to the darker colors as used in Calcite-Web
+- Changed color values for `$brand-success` and `$brand-danger` variables to match what is used in Calcite-Web
+- Removed `!important` off of `.btn-default`
+
 ## v0.2.10
 ### Changed
 - Removed scss file for Calcite fonts and replaced import with direct fast.fonts url.

--- a/lib/sass/calcite/_buttons-custom.scss
+++ b/lib/sass/calcite/_buttons-custom.scss
@@ -22,8 +22,8 @@
 
 .btn-default {
   &:hover, :active {
-    background-color: $Calcite_Blue_a250 !important;
-    color: $Calcite_Gray_050 !important;
+    background-color: $Calcite_Highlight_Blue_400;
+    color: $Calcite_Gray_050;
   }
   &:focus {
     background-color: $Calcite_Gray_050;
@@ -33,35 +33,35 @@
 
 .btn-primary {
   &:hover {
-    background-color: $Calcite_Blue_a200;
-    border-color: $Calcite_Blue_a200;
+    background-color: $Calcite_Highlight_Blue_400;
+    border-color: $Calcite_Highlight_Blue_400;
   }
 }
 
 .btn-success {
   &:hover {
-    background-color: $Calcite_Green_250;
-    border-color: $Calcite_Green_250;
+    background-color: $Calcite_Green_a200;
+    border-color: $Calcite_Green_a200;
   }
 }
 
 .btn-info {
   &:hover {
-    background-color: $Calcite_Blue_100;
-    color: $Calcite_Gray_650;
+    background-color: $Calcite_Highlight_Blue_400;
+    color: $Calcite_Gray_050;
   }
 }
 
 .btn-warning {
   &:hover {
-    background-color: $Calcite_Yellow_100;
+    background-color: $Calcite_Yellow_a150;
     color: $Calcite_Gray_650;
   }
 }
 
 .btn-danger {
   &:hover {
-    background-color: $Calcite_Red_a100;
+    background-color: $Calcite_Red_a200;
   }
 }
 

--- a/lib/sass/calcite/_variables.scss
+++ b/lib/sass/calcite/_variables.scss
@@ -16,10 +16,10 @@ $gray-light:			 $Calcite_Gray_400 !default;
 $gray-lighter:			 $Calcite_Gray_350 !default;
 
 $brand-primary:			 $Calcite_Blue_a250 !default;
-$brand-success:			 $Calcite_Green_a200 !default;
+$brand-success:			 $Calcite_Green_250 !default;
 $brand-info:			 $Calcite_Blue_250 !default;
 $brand-warning:			 $Calcite_Yellow_200 !default;
-$brand-danger:			 $Calcite_Red_a150 !default;
+$brand-danger:			 $Brand_Red_100 !default;
 
 //## Calcite Custom
 $transparent-background:		rgba($Calcite_Gray_050, .3);


### PR DESCRIPTION
Fixes issues #214 and #223

- Changed background color on hover for `.btn-default`, `.btn-primary`, `.btn-success`, `.btn-info`, `.btn-warning` and `.btn-danger` to the darker colors as used in Calcite-Web
- Changed color values for `$brand-success` and `$brand-danger` variables to match what is used in Calcite-Web
- Removed `!important` off of `.btn-default`