### PR TITLE
Navbar restyling for issue #230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 For information about how to add entries to this file, please read [Keep a CHANGELOG](http://keepachangelog.com/)
 
+##v0.3.0
+### Changed
+- Lots of style changes to the navbar. Default height is now 65px, up from 50px. On hover the accent bar is now below the link instead of above. Tightened up the padding and margin on links significantly. This also makes the accent bar only the width of the text above it. Added custom rule for padding on the active links.
+
 ##v0.2.12
 ### Changed
 - Removed old notes file and updated NPM command

--- a/lib/sass/calcite/_navbar-custom.scss
+++ b/lib/sass/calcite/_navbar-custom.scss
@@ -19,7 +19,9 @@
 .navbar-form button,
 .navbar-nav .dropdown-menu {
 	font-weight: 400;
-	font-size: ceil(($font-size-base * 0.9));
+	font-size: $font-size-base;
+  letter-spacing: 0px;
+
 	// Bump weight of span for branding up coinciding with navbar-nav
 	.gis {
 		font-weight: 600;
@@ -51,9 +53,13 @@
 .navbar-nav {
   > li {
     > a {
+      padding-left: 0px;
+      padding-right: 0px;
+      margin-left: 8px;
+      margin-right: 8px;
       &:hover,
       &:focus {
-        background-image: linear-gradient(to top, transparent 92%, $Calcite_Blue_a200 93%, $Calcite_Blue_a200 100%);
+        background-image: linear-gradient(to bottom, transparent 92%, $Calcite_Highlight_Blue_350 93%, $Calcite_Highlight_Blue_350 100%);
         transition: color 150ms linear, text-decoration 150ms linear;
       }
       @media (max-width: 767px) {
@@ -66,3 +72,8 @@
   }
 }
 
+// Adds padding to active navbar links
+.navbar-default .navbar-nav > .active > a, .navbar-inverse .navbar-nav > .active > a {
+  padding-left: 8px;
+  padding-right: 8px;
+}

--- a/lib/sass/calcite/_variables.scss
+++ b/lib/sass/calcite/_variables.scss
@@ -367,7 +367,7 @@ $container-lg:                 $container-large-desktop !default;
 //##
 
 // Basics of a navbar
-$navbar-height:                    50px !default;
+$navbar-height:                    65px !default;
 $navbar-margin-bottom:             0px !default;
 $navbar-border-radius:             $border-radius-base !default;
 $navbar-padding-horizontal:        floor(($grid-gutter-width / 2)) !default;


### PR DESCRIPTION
Lots of style changes to the navbar. Default height is now 65px, up from 50px. On hover the accent bar is now below the link instead of above. Tightened up the padding and margin on links significantly. This also makes the accent bar only the width of the text above it. Added custom rule for padding on the active links.