### PR TITLE
Styling update for navbar user menu and dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For information about how to add entries to this file, please read [Keep a CHANG
 ##v0.3.0
 ### Changed
 - Lots of style changes to the navbar. Default height is now 65px, up from 50px. On hover the accent bar is now below the link instead of above. Tightened up the padding and margin on links significantly. This also makes the accent bar only the width of the text above it. Added custom rule for padding on the active links.
+- Styling changes to dropdowns include adding border between menu items, changing the background color on hover to `$Calcite_Gray_100`, changing the link and link-hover colors to `$Calcite_Gray_200`, changed the menu border color to match item border color, lighten box-shadow of menu, tighten up padding around menu items and menu headers.
 
 ##v0.2.12
 ### Changed

--- a/lib/sass/calcite/_dropdowns-custom.scss
+++ b/lib/sass/calcite/_dropdowns-custom.scss
@@ -4,11 +4,20 @@
 
 .dropdown-header {
   background-color: $Calcite_Gray_100;
-  border-bottom: 1px solid $Calcite_Gray_350;
+  border-bottom: 1px solid $Calcite_Gray_200;
   font-size: 16px;
-  padding-top: 8px;
-  padding-bottom: 8px;
+  padding: 8px 10px;
 }
+
+// Dropdown section headers
+//.dropdown-header {
+//  display: block;
+//  padding: 3px 20px;
+//  font-size: $font-size-small;
+//  line-height: $line-height-base;
+//  color: $dropdown-header-color;
+//  white-space: nowrap; // as with > li > a
+//}
 
 .dropdown, .dropup {
   &.open {
@@ -19,8 +28,9 @@
 }
 
 .dropdown-menu {
+  @include box-shadow(0 0 16px 0 rgba(0,0,0,.05));
   li {
-    border-top: 0 !important;
+    border-top: 1px solid $Calcite_Gray_200;
   }
   padding: 0;
   .divider {
@@ -28,8 +38,10 @@
   }
   li {
     a {
-      padding-top: 8px;
-      padding-bottom: 8px;
+      padding: 10px;
     }
+  }
+  .glyphicon {
+    padding-right: 10px;
   }
 }

--- a/lib/sass/calcite/_navbar-custom.scss
+++ b/lib/sass/calcite/_navbar-custom.scss
@@ -9,6 +9,15 @@
   margin-right: 0px;
 }
 
+// Places a small profile image in the user menu
+.navbar-icon {
+  width: 32px;
+  position: relative;
+  float: left;
+  padding-right: 6px;
+  padding-bottom: 10px;
+}
+
 // Sets the font-size of the brand and navbar links slightly smaller than base
 .navbar-nav,
 .navbar-brand,
@@ -41,13 +50,7 @@
 	}
 }
 
-// Places a small profile image in the user menu
-.navbar-icon {
-	width: 28px;
-  position: relative;
-  float: left;
-  padding-right: 6px;
-}
+
 
 // Add a rule and color transition to the top of navbar nav links
 .navbar-nav {
@@ -73,7 +76,8 @@
 }
 
 // Adds padding to active navbar links
-.navbar-default .navbar-nav > .active > a, .navbar-inverse .navbar-nav > .active > a {
+.navbar-default .navbar-nav > .active > a,
+.navbar-inverse .navbar-nav > .active > a {
   padding-left: 8px;
   padding-right: 8px;
 }

--- a/lib/sass/calcite/_variables.scss
+++ b/lib/sass/calcite/_variables.scss
@@ -244,23 +244,23 @@ $cursor-disabled:                not-allowed !default;
 //** Background for the dropdown menu.
 $dropdown-bg:                    $Calcite_Gray_050 !default;
 //** Dropdown menu `border-color`.
-$dropdown-border:                rgba(0,0,0,.15) !default;
+$dropdown-border:                $Calcite_Gray_200 !default;
 //** Dropdown menu `border-color` **for IE8**.
-$dropdown-fallback-border:       $Calcite_Gray_350 !default;
+$dropdown-fallback-border:       $Calcite_Gray_200 !default;
 //** Divider color for between dropdown items.
-$dropdown-divider-bg:            $Calcite_Gray_350 !default;
+$dropdown-divider-bg:            $Calcite_Gray_200 !default;
 
 //** Dropdown link text color.
-$dropdown-link-color:            $Calcite_Gray_650 !default;
+$dropdown-link-color:            $Calcite_Gray_550 !default;
 //** Hover color for dropdown links.
-$dropdown-link-hover-color:      darken($Calcite_Gray_650, 5%) !default;
+$dropdown-link-hover-color:      $Calcite_Gray_550 !default;
 //** Hover background for dropdown links.
-$dropdown-link-hover-bg:         $Calcite_Gray_200 !default;
+$dropdown-link-hover-bg:         $Calcite_Gray_100 !default;
 
 //** Active dropdown menu item text color.
-$dropdown-link-active-color:     $component-active-color !default;
+$dropdown-link-active-color:     $Calcite_Gray_650 !default;
 //** Active dropdown menu item background color.
-$dropdown-link-active-bg:        $component-active-bg !default;
+$dropdown-link-active-bg:        $Calcite_Gray_100 !default;
 
 //** Disabled dropdown menu item background color.
 $dropdown-link-disabled-color:   $gray-light !default;


### PR DESCRIPTION
Styling changes to dropdowns include adding border between menu items, changing the background color on hover to `$Calcite_Gray_100`, changing the link and link-hover colors to `$Calcite_Gray_200`, changed the menu border color to match item border color, lighten box-shadow of menu, tighten up padding around menu items and menu headers.

Closes issue #235