### PR TITLE
Fixed bug in breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For information about how to add entries to this file, please read [Keep a CHANG
 ##v0.3.2
 ### Changed
 - Bug fixes that was causing styling rules to be overwritten by core on navbar, nav-tabs and dropdown menus.
+- Updated Bootstrap Sass dependency to 3.3.6 to fix breadcrumb bug
 
 ##v0.3.1
 ### Changed

--- a/lib/sass/calcite/_variables.scss
+++ b/lib/sass/calcite/_variables.scss
@@ -873,6 +873,8 @@ $blockquote-border-color:     $gray-lighter !default;
 $page-header-border-color:    $gray-lighter !default;
 //** Width of horizontal description list titles
 $dl-horizontal-offset:        $component-offset-horizontal !default;
+//** Point at which .dl-horizontal becomes horizontal
+$dl-horizontal-breakpoint:    $grid-float-breakpoint !default;
 //** Horizontal line color.
 $hr-border:                   $gray-lighter !default;
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "jsonfile": "^2.2.2"
   },
   "dependencies": {
-    "bootstrap-sass": "3.3.5"
+    "bootstrap-sass": "3.3.6"
 
   }
 }


### PR DESCRIPTION
Updated the dependency to the latest version of Bootstrap Core. This fixed a known bug in the Breadcrumbs.

Note that this patch includes a new variable in the variables.css file.