### PR TITLE
Fix active default button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 For information about how to add entries to this file, please read [Keep a CHANGELOG](http://keepachangelog.com/)
 
+## [Unreleased]
+### Fixed
+- Bug where the ".btn-default" elements' ":active" styling is applied to its active children instead of itself.
+
 ##v0.3.2
 ### Changed
 - Bug fixes that was causing styling rules to be overwritten by core on navbar, nav-tabs and dropdown menus.

--- a/lib/sass/calcite/_buttons-custom.scss
+++ b/lib/sass/calcite/_buttons-custom.scss
@@ -21,7 +21,7 @@
 }
 
 .btn-default {
-  &:hover, :active {
+  &:hover, &:active {
     background-color: $Calcite_Highlight_Blue_400;
     color: $Calcite_Gray_050;
   }


### PR DESCRIPTION
Fix an issue where styles for the default button’s “active” state are
applied to the button’s active child elements instead.