### PR TITLE
Fix docs CSS 404

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -363,9 +363,8 @@ module.exports = function(grunt) {
     // Runs tasks concurrently, speeding up Grunt
     'concurrent': {
       prepublish: [
-        'scss',
+        ['scss', 'copy'],
         //'uglify',
-        'copy',
         //'concat:dist',
         'newer:imagemin:dist'
       ]


### PR DESCRIPTION
Fix an issue where the initial build task can generate a build of the
“docs” site that is missing the calcite CSS.

As reported in #259.