### PR TITLE
Clean docs

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -356,7 +356,10 @@ module.exports = function(grunt) {
     // Clean the build folder before rebuild
     clean: {
       dist: {
-        src: [ 'dist/' ]
+        src: [
+          'dist/',
+          'docs/build'
+        ]
       },
     },
 


### PR DESCRIPTION
Remove the generated docs site when `grunt clean` is run (#261).