### PR TITLE
Validation states on select controls.

### DIFF
--- a/lib/sass/calcite/_forms-custom.scss
+++ b/lib/sass/calcite/_forms-custom.scss
@@ -15,6 +15,18 @@ select.form-control {
   &:focus {
     outline: 1px inset $Calcite_Blue_a200;
   }
+
+  .has-success & {
+    outline-color: $state-success-border;
+  }
+
+  .has-warning & {
+    outline-color: $state-warning-border;
+  }
+
+  .has-error & {
+    outline-color: $state-danger-border;
+  }
 }
 
 select.form-control#disabledSelect {


### PR DESCRIPTION
Fix an issue where Bootstrap’s validation state border styling is not
visible on Calcite’s select menu controls.

As reported in #201.