### PR TITLE
Fix license warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "files": [
     "dist/"
   ],
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/esri/calcite-bootstrap/issues"
   },


### PR DESCRIPTION
Commands in somewhat recent versions of `npm` are emitting a "license should be a valid SPDX license expression" warning. This change updates Calcite Bootstrap's package license with a valid [Apache 2.0 identifier](https://spdx.org/licenses/Apache-2.0.html).