### PR TITLE
removed all important tags from calcite/.scss files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ For information about how to add entries to this file, please read [Keep a CHANG
 ### Added
 - `grunt clean` removes the generated docs ([#261](https://github.com/Esri/calcite-bootstrap/issues/261)).
 
+### Removed
+- Removed all `!important` tags in .scss files inside Calcite directory.
+
 ### Fixed
 - Bug where the ".btn-default" elements' ":active" styling is applied to its active children instead of itself ([#257](https://github.com/Esri/calcite-bootstrap/pull/257)).
 - Restore Bootrap's validation state styling ([#201](https://github.com/Esri/calcite-bootstrap/issues/201)).
@@ -51,7 +54,7 @@ For information about how to add entries to this file, please read [Keep a CHANG
 - Color for links was too dark to pass accessibility. Value for `$link-color` variable was changed.
 - Custom Cards pattern added. [Example](http://esri.github.io/calcite-bootstrap/examples/#card)
 
-## v0.2.9 
+## v0.2.9
 ### Added
 - Calcite Dark colors finalized
 - Consolidated custom variable definitions into `_variables.scss` file.
@@ -76,7 +79,7 @@ For information about how to add entries to this file, please read [Keep a CHANG
 
 ## v0.2.4
 ### Changed
-- updated the very old grunt-sass which was using a very old node-sass which could not handle @at-root and thus passed it thru into the css... breaking the glyphicons. 
+- updated the very old grunt-sass which was using a very old node-sass which could not handle @at-root and thus passed it thru into the css... breaking the glyphicons.
 
 ## v0.2.3
 ### Changed

--- a/lib/sass/calcite/_buttons-custom.scss
+++ b/lib/sass/calcite/_buttons-custom.scss
@@ -8,7 +8,7 @@
 }
 
 .btn-link {
-  color: $link-color !important;
+  color: $link-color;
 }
 
 .btn-group.open {

--- a/lib/sass/calcite/_dropdowns-custom.scss
+++ b/lib/sass/calcite/_dropdowns-custom.scss
@@ -37,7 +37,7 @@
   }
   li {
     a {
-      padding: 10px !important;
+      padding: 10px;
     }
   }
   .glyphicon {

--- a/lib/sass/calcite/_navbar-custom.scss
+++ b/lib/sass/calcite/_navbar-custom.scss
@@ -47,8 +47,8 @@
 .navbar-nav {
   > li {
     > a {
-      padding-left: 0px !important;
-      padding-right: 0px !important;
+      padding-left: 0px;
+      padding-right: 0px;
       margin-left: 8px;
       margin-right: 8px;
       &:hover,
@@ -60,7 +60,7 @@
         &:hover,
         &:focus {
           background-image: none;
-        }         
+        }
       }
     }
   }

--- a/lib/sass/calcite/_navs-tabs-custom.scss
+++ b/lib/sass/calcite/_navs-tabs-custom.scss
@@ -6,8 +6,8 @@
   > li {
     > a {
       border: 1px solid transparent;
-      border-left: 0px !important;
-      border-right: 0px !important;
+      border-left: 0px;
+      border-right: 0px;
       &:hover {
         padding-top: 5px;
         -moz-box-sizing: border-box;
@@ -21,7 +21,7 @@
   }
 }
 
-// Compensate for active tab inheriting the padding top on hover from above 
+// Compensate for active tab inheriting the padding top on hover from above
 .nav-tabs > li.active > a {
   &:hover {
     padding-top: 6px;


### PR DESCRIPTION
We're still having issues on the Dashboard with !important tags on Calcite-Bootstrap.
Removed all `!important` tags on Calcite-Bootstrap.

The library should not have `!important` tags.