### PR TITLE
Bump bootstrap-sass, to allow use of jquery 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "jsonfile": "^2.2.2"
   },
   "dependencies": {
-    "bootstrap-sass": "3.3.6"
+    "bootstrap-sass": "~3.3.7"
 
   }
 }


### PR DESCRIPTION
bootstrap-sass 3.3.7 supports jquery 3.x, whereas 3.3.6 throws an error if jquery is greater than 2.x.  Some of our other dependencies want to use jquery 3.x, and this allows them to do so.