### PR TITLE
to-fix-bug: removed font-weights that were numbers and/or replaced with bold/normal

### DIFF
--- a/calcite-bootstrap/lib/sass/calcite/_card-custom.scss
+++ b/calcite-bootstrap/lib/sass/calcite/_card-custom.scss
@@ -1,0 +1,161 @@
+// ┌───────┐
+// │ Cards │
+// └───────┘
+
+.cards-list {
+  margin: 0;
+  padding: 0;
+
+  & > li {
+    float: left;
+    padding: 0 13px;
+  }
+
+  li {
+    list-style: none;
+  }
+}
+
+.card {
+  position: relative;
+  display: inline-block;
+  padding: 20px;
+  margin-bottom: 40px;
+  background-color: white;
+  border: 1px solid $Calcite_Gray_350;
+  text-align: center;
+  width: $card-width;
+  height: 296px;
+
+  img {
+    height: $card-thumb-max-height;
+    max-width: $card-thumb-max-width;
+  }
+
+  hr {
+    margin: 1.7rem -1.7rem;
+    border-top: 1px solid $Calcite_Gray_250;
+  }
+
+  h6 {
+    $title-line-height: 1.55;
+    $title-lines-to-show: 2;
+    font-weight: normal;
+    color: $Calcite_Gray_650;
+    display: block;
+    display: -webkit-box;
+    height: 4rem;
+    line-height: 1.55rem;
+    -webkit-line-clamp: $title-lines-to-show;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.card-info {
+  left: 0;
+  padding: 0 2px;
+  margin: 0;
+  width: 100%;
+  line-height: 1.7rem;
+  color: $Calcite_Gray_550;
+  font-size: 1.3rem;
+
+  li {
+    display: inline;
+
+    &:first-of-type:after {
+      content: " • ";
+    }
+  }
+}
+
+.card-options {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  color: white;
+  opacity: 0;
+  background:(linear-gradient(rgba(black, 0.6) 0, rgba(black, 0.6) 172px, transparent 173px, rgba(white, 0) 100%));
+  transition:(opacity ease-in-out 400ms);
+
+  .glyphicon {
+    visibility: hidden;
+    right: -30px;
+    margin-left: 10px;
+    transition:(600ms);
+
+    &:nth-child(2) {
+      transition:(900ms);
+    }
+    &:nth-child(3) {
+      transition:(1200ms);
+    }
+    &:nth-child(4) {
+      transition:(1500ms);
+    }
+  }
+
+  &:hover, &:active, &:focus {
+    opacity: 1;
+    cursor: pointer;
+    box-shadow:(0 0 10px 1px rgba(0, 0, 0, 0.2));
+
+    & > button {
+      transform: translateY(30px);
+      visibility: visible;
+    }
+
+    & .glyphicon {
+      transform: translateX(-30px);
+      visibility: visible;
+    }
+
+    & li {
+      visibility: visible;
+    }
+  }
+
+  ul {
+    position: absolute;
+    right: 12px;
+    top: 12px;
+    color: white;
+    font-size: rem(17px);
+
+    li {
+      visibility: hidden;
+      width: 1.7rem;
+      float: right;
+      margin-right: -.12rem;
+      cursor: pointer;
+      visibility: hidden;
+
+    }
+  }
+
+  button {
+    background: rgba(255,255,255,.1);
+    display: inline-block;
+    padding: 10px;
+    margin-top: 2.4rem;
+    text-decoration: none;
+    border: 1px solid white;
+    color: white;
+    cursor: pointer;
+    transition:(300ms);
+    visibility: hidden;
+    font-size: 1.5rem;
+    line-height: 1.6rem;
+
+    &:hover, &:active, &:focus {
+      text-decoration: none;
+      border: 1px solid white;
+      color: white;
+      background: rgba(255, 255, 255, 0.3);
+    }
+  }
+}

--- a/calcite-bootstrap/lib/sass/calcite/_navbar-custom.scss
+++ b/calcite-bootstrap/lib/sass/calcite/_navbar-custom.scss
@@ -1,0 +1,74 @@
+// ┌────────────────┐
+// │ Navbar: Custom │
+// └────────────────┘
+
+// Moves the hamburger icon to the left side of the navbar
+.navbar-toggle{
+  float: left;
+  margin-left: $navbar-padding-horizontal;
+  margin-right: 0px;
+}
+
+// Places a small profile image in the user menu
+.navbar-icon {
+  width: 32px;
+  position: relative;
+  float: left;
+  padding-right: 6px;
+  padding-bottom: 10px;
+}
+
+// Sets the font-size of the brand and navbar links slightly smaller than base
+.navbar-nav,
+.navbar-brand,
+.navbar-btn,
+.navbar-text,
+.navbar-form,
+.navbar-form input,
+.navbar-form button,
+.navbar-nav .dropdown-menu {
+	font-weight: normal;
+	font-size: $font-size-base;
+  letter-spacing: 0px;
+	// Bump weight of span for branding up coinciding with navbar-nav
+	.gis {
+		font-weight: 600;
+	}
+}
+
+// Ease the hover state in and out
+.navbar-brand {
+	&:hover {
+		transition: color 150ms linear, text-decoration 150ms linear;
+	}
+}
+
+// Add a rule and color transition to the top of navbar nav links
+.navbar-nav {
+  > li {
+    > a {
+      padding-left: 0px !important;
+      padding-right: 0px !important;
+      margin-left: 8px;
+      margin-right: 8px;
+      &:hover,
+      &:focus {
+        background-image: linear-gradient(to bottom, transparent 92%, $Calcite_Highlight_Blue_350 93%, $Calcite_Highlight_Blue_350 100%);
+        transition: color 150ms linear, text-decoration 150ms linear;
+      }
+      @media (max-width: 767px) {
+        &:hover,
+        &:focus {
+          background-image: none;
+        }         
+      }
+    }
+  }
+}
+
+// Adds padding to active navbar links
+.navbar-default .navbar-nav > .active > a,
+.navbar-inverse .navbar-nav > .active > a {
+  padding-left: 8px;
+  padding-right: 8px;
+}

--- a/calcite-bootstrap/lib/sass/calcite/_panels-custom.scss
+++ b/calcite-bootstrap/lib/sass/calcite/_panels-custom.scss
@@ -1,0 +1,21 @@
+// ┌───────────────┐
+// │ Panels-custom │
+// └───────────────┘
+
+.panel {
+  .panel-heading {
+    h3 {
+      font-weight: normal;
+    }
+  }
+  &.panel-success,
+  &.panel-info,
+  &.panel-warning,
+  &.panel-danger
+  {
+    .panel-heading {
+      color: $Calcite_Gray_600;
+    }
+
+  }
+}

--- a/calcite-bootstrap/lib/sass/calcite/_type-custom.scss
+++ b/calcite-bootstrap/lib/sass/calcite/_type-custom.scss
@@ -1,0 +1,37 @@
+// ┌────────────────────┐
+// │ Typography: Custom │
+// └────────────────────┘
+
+// Adjust base font to match Calcite Web
+body {
+  font-size: ceil(($font-size-base * 1.05)); // ~17px
+  letter-spacing: .03em;
+}
+
+// Increases the margin-bottom to match Calcite Web
+h1, .h1,
+h2, .h2,
+h3, .h3,
+h4, .h4,
+h5, .h5,
+h6, .h6 {
+  margin-top: 0px;
+  margin-bottom: ($line-height-computed / 1);
+}
+
+.serif-face {
+  font-family: $font-family-serif;
+}
+
+.code-face {
+  font-family: $font-family-monospace;
+}
+
+blockquote {
+  font-family: $font-family-serif;
+}
+
+// Use the class below in a span around GIS when branding ArcGIS
+.gis {
+	font-weight: 500; 
+}


### PR DESCRIPTION
Using `font-weight: 300` on `.body` class in type and some of the other numbers, unfortunately, renders some glyphs in Avenir Next causing the mixed font weight bug seen here:

![image](https://cloud.githubusercontent.com/assets/7389593/21572462/042f0230-cea7-11e6-95b4-a40634c97d20.png)

Removed it from the `.body` class allowing Avenir Next to default to weight, which is supported by these languages. In some instances, replaced number with 'normal' or 'bold'.