### PR TITLE
modifying font weights

### DIFF
--- a/lib/sass/calcite/_card-custom.scss
+++ b/lib/sass/calcite/_card-custom.scss
@@ -40,7 +40,7 @@
   h6 {
     $title-line-height: 1.55;
     $title-lines-to-show: 2;
-    font-weight: 400;
+    font-weight: normal;
     color: $Calcite_Gray_650;
     display: block;
     display: -webkit-box;

--- a/lib/sass/calcite/_header-custom.scss
+++ b/lib/sass/calcite/_header-custom.scss
@@ -16,7 +16,7 @@
 	h1 {
 		margin-top: 0;
 		font-size: $font-size-h1;
-		font-weight: 300;
+		font-weight: lighter;
 		line-height: 1.25;
 		@media (max-width: $screen-sm) {
 		    font-size: $font-size-large;
@@ -26,7 +26,7 @@
 	h2 {
 		margin-top: 0;
 		font-size: 1.6em;
-		font-weight: 400;
+		font-weight: normal;
 		line-height: 1;
 		@media (max-width: $screen-sm) {
 		    font-size: $font-size-large;

--- a/lib/sass/calcite/_navbar-custom.scss
+++ b/lib/sass/calcite/_navbar-custom.scss
@@ -27,7 +27,7 @@
 .navbar-form input,
 .navbar-form button,
 .navbar-nav .dropdown-menu {
-	font-weight: 400;
+	font-weight: normal;
 	font-size: $font-size-base;
   letter-spacing: 0px;
 	// Bump weight of span for branding up coinciding with navbar-nav

--- a/lib/sass/calcite/_panels-custom.scss
+++ b/lib/sass/calcite/_panels-custom.scss
@@ -5,7 +5,7 @@
 .panel {
   .panel-heading {
     h3 {
-      font-weight: 500;
+      font-weight: normal;
     }
   }
   &.panel-success,

--- a/lib/sass/calcite/_type-custom.scss
+++ b/lib/sass/calcite/_type-custom.scss
@@ -4,7 +4,6 @@
 
 // Adjust base font to match Calcite Web
 body {
-  font-weight: 300;
   font-size: ceil(($font-size-base * 1.05)); // ~17px
   letter-spacing: .03em;
 }


### PR DESCRIPTION
Reference: [283](https://github.com/Esri/calcite-bootstrap/pull/283#issuecomment-272267367) I put my changes in the wrong place. 

@jrowlingson I saw that you removed the untracked files I accidentally added, thank you. Here's my corrections. I understand that in theory `font-weight: 500` is the same as `font-weight: normal`, but I think it's something around how the browser requires the font have those weights in order to use numbers whereas it can force lighter/normal/bold. I don't know anything about the unicode-range thing you suggested. If you'd rather patch the bug that way, you all can ignore my PR, and take that on.